### PR TITLE
Update dps with correct cid

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -43,6 +43,7 @@ import json
 import logging
 import struct
 import time
+from tkinter import W
 import weakref
 from abc import ABC, abstractmethod
 from collections import namedtuple
@@ -393,7 +394,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         def _status_update(msg):
             decoded_message = self._decode_payload(msg.payload)
             if "dps" in decoded_message:
-                self.dps_cache.update(decoded_message["dps"])
+                if "cid" in decoded_message:
+                    if decoded_message["cid"] == self.id:
+                        self.dps_cache.update(decoded_message["dps"])
 
             listener = self.listener and self.listener()
             if listener is not None:

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -43,7 +43,6 @@ import json
 import logging
 import struct
 import time
-from tkinter import W
 import weakref
 from abc import ABC, abstractmethod
 from collections import namedtuple


### PR DESCRIPTION
In the user case of Holman WX1 and WX2 Tap Timer connected to the same Wi-Fi hub, some of the DPS used are the same. We need to check the CID in the status message to determine which device to update with the status DPS.